### PR TITLE
cause grunt to fail on selector count about 4095

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Default value: `false`
 
 If set to `true`, you'll get output with all file selectors count. If set to `warn`, you'll get only log messages only on files that reached CSS selectors limit.
 
+#### options.failOnLimit ####
+
+Type: `Boolean`
+Default value: `false`
+
+If set to `true,` the process will exit with an error if the selector limit is exceeded.
+
 ### Usage Examples ###
 
 #### Default Options ####

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -24,8 +24,8 @@ module.exports = function(grunt) {
 			logCount: false,
 			force: grunt.option('force') || false,
 			warnLimit: 4000,
-      imports: true,
-      failOnLimit: false
+ 			imports: true,
+ 			failOnLimit: false
 		});
 		grunt.log.writeflags(options, 'options');
 
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
 					}
 
 					var coungMsg = path.basename(outPutfileName) + ' has ' + _numSelectors + ' CSS selectors.';
-          var overLimitErrorMessage = coungMsg + ' IE8-9 will read only first ' + limit + '!';
+					var overLimitErrorMessage = coungMsg + ' IE8-9 will read only first ' + limit + '!';
 					if (overLimit) {
 						if (options.failOnLimit) {
 							grunt.fatal(overLimitErrorMessage);

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -79,7 +79,11 @@ module.exports = function(grunt) {
 					var coungMsg = path.basename(outPutfileName) + ' has ' + _numSelectors + ' CSS selectors.';
 
 					if (overLimit) {
-						grunt.log.errorlns(coungMsg + ' IE8-9 will read only first ' + limit + '!');
+            if (options.failOnError) {
+							grunt.fatal(coungMsg + ' IE8-9 will read only first ' + limit + '!');
+            } else {
+              grunt.log.errorlns(coungMsg + ' IE8-9 will read only first ' + limit + '!');
+            }
 					} else if (options.logCount !== 'warn') {
 						grunt.log.oklns(coungMsg);
 					}

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
 			logCount: false,
 			force: grunt.option('force') || false,
 			warnLimit: 4000,
-			imports: true
+      imports: true,
+      failOnLimit: false
 		});
 		grunt.log.writeflags(options, 'options');
 
@@ -77,13 +78,13 @@ module.exports = function(grunt) {
 					}
 
 					var coungMsg = path.basename(outPutfileName) + ' has ' + _numSelectors + ' CSS selectors.';
-
+          var overLimitErrorMessage = coungMsg + ' IE8-9 will read only first ' + limit + '!';
 					if (overLimit) {
-            if (options.failOnError) {
-							grunt.fatal(coungMsg + ' IE8-9 will read only first ' + limit + '!');
-            } else {
-              grunt.log.errorlns(coungMsg + ' IE8-9 will read only first ' + limit + '!');
-            }
+						if (options.failOnLimit) {
+							grunt.fatal(overLimitErrorMessage);
+						} else {
+							grunt.log.errorlns(overLimitErrorMessage);
+						}
 					} else if (options.logCount !== 'warn') {
 						grunt.log.oklns(coungMsg);
 					}


### PR DESCRIPTION
When doing a build, it is sometimes helpful to be able to fail out (e.g. for CI) if a CSS file is over the limit.

The auto-split behavior is nice, but not always appropriate. Since you sometimes need to manually update your templates or html, some people might prefer a stop-the-build mode of operation.

This PR adds an option called failOnError that will cause grunt to fail out when the selector count is over the limit.